### PR TITLE
feat : 디데이 삭제 기능 구현 및 DdayItem 컴포넌트 생성

### DIFF
--- a/src/components/dday/CreateDday.jsx
+++ b/src/components/dday/CreateDday.jsx
@@ -24,7 +24,7 @@ const day = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
   23, 24, 25, 26, 27, 28, 29, 30, 31,
 ];
-export const DdayAdd = ({ data, setData }) => {
+export const CreateDday = ({ data, setData, onClickAddDday }) => {
   const [ddayName, setDdayName] = useState("");
   const [selectYear, setSelectYear] = useState(years[0]);
   const [selectMonth, setSelectMonth] = useState(month[d.getMonth()]);
@@ -58,7 +58,7 @@ export const DdayAdd = ({ data, setData }) => {
   }, [data]);
   return (
     <DdayAddWrapper>
-      <form>
+      <form onSubmit={onClickSubmitDday}>
         <label>
           기념일 명
           <Input
@@ -112,11 +112,11 @@ export const DdayAdd = ({ data, setData }) => {
           </select>
           일
         </DdaySelectDiv>
-        <SubmitBtn onClick={onClickSubmitDday}>등록</SubmitBtn>
-        <DeleteButton bottom="5px" right="7px">
-          +
-        </DeleteButton>
+        <SubmitBtn>등록</SubmitBtn>
       </form>
+      <DeleteButton onClick={onClickAddDday} bottom="5px" right="7px">
+        +
+      </DeleteButton>
     </DdayAddWrapper>
   );
 };

--- a/src/components/dday/Dday.jsx
+++ b/src/components/dday/Dday.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { DdayAdd } from "./DdayAdd";
+import { CreateDday } from "./CreateDday";
 import { DdayWrapper } from "./styled";
 import { DdayList } from "./DdayList";
 import CreateButton from "../common/Button/CreateButton";
@@ -7,13 +7,9 @@ import CreateButton from "../common/Button/CreateButton";
 export const Dday = () => {
   const [hidden, setHidden] = useState(true);
   const [data, setData] = useState([]);
+
   // 등록 화면 보여주는 함수
   const onClickAddDday = () => {
-    setHidden(!hidden);
-  };
-
-  // 디데이 수정 시 li 클릭하면 등록 화면 보여주는 함수
-  const onClickEditDday = () => {
     setHidden(!hidden);
   };
 
@@ -28,11 +24,15 @@ export const Dday = () => {
   return (
     <>
       <DdayWrapper>
-        <DdayList onClickAddDday={onClickAddDday} data={data} />
+        <DdayList data={data} setData={setData} />
 
         {hidden === false ? (
           <>
-            <DdayAdd data={data} setData={setData} />
+            <CreateDday
+              data={data}
+              setData={setData}
+              onClickAddDday={onClickAddDday}
+            />
           </>
         ) : (
           <CreateButton onClick={onClickAddDday} bottom="10px" right="10px">

--- a/src/components/dday/DdayItem.jsx
+++ b/src/components/dday/DdayItem.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { DdayDeleteBox, DdayTitle } from "./styled";
+
+export const DdayItem = ({ item, data, setData }) => {
+  const { id, title, date, difDay } = item;
+
+  // 디데이 삭제
+  const onClickDeleteDay = (id) => {
+    setData(data.filter((todo) => todo.id !== id));
+  };
+  return (
+    <li key={id}>
+      <DdayTitle>
+        {title} <span>{date}</span>
+      </DdayTitle>
+      <span>
+        D{difDay >= 0 ? "-" : "+"}
+        {difDay === 0 ? "day" : Math.abs(difDay)}
+      </span>
+      <DdayDeleteBox
+        key={`${id}-box`}
+        id="itembox"
+        onClick={() => onClickDeleteDay(id)}
+      >
+        삭제
+      </DdayDeleteBox>
+    </li>
+  );
+};

--- a/src/components/dday/DdayList.jsx
+++ b/src/components/dday/DdayList.jsx
@@ -1,17 +1,13 @@
 import React from "react";
-import { DdayListUl, DdayListWrapper, DdayTitle } from "./styled";
+import { DdayListUl, DdayListWrapper } from "./styled";
+import { DdayItem } from "./DdayItem";
 
-export const DdayList = ({ onClickAddDday, data }) => {
+export const DdayList = ({ data, setData }) => {
   return (
     <DdayListWrapper>
       <DdayListUl>
         {data.map((item) => (
-          <li key={item.id} onClick={onClickAddDday}>
-            <DdayTitle>
-              {item.title} <span>{item.date}</span>
-            </DdayTitle>
-            <span>D-{item.difDay}</span>
-          </li>
+          <DdayItem key={item.id} item={item} data={data} setData={setData} />
         ))}
       </DdayListUl>
     </DdayListWrapper>

--- a/src/components/dday/styled.jsx
+++ b/src/components/dday/styled.jsx
@@ -88,11 +88,19 @@ export const DdayListUl = styled.ul`
   overflow-y: scroll;
 
   & > li {
+    position: relative;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     height: 35px;
+  }
+  & > li:hover {
+    #itembox {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   ${({ theme }) => {
@@ -119,4 +127,22 @@ export const DdayTitle = styled.div`
       `;
     }}
   }
+`;
+
+export const DdayDeleteBox = styled.div`
+  display: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+
+  background-color: rgba(190, 190, 190, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 10px;
+
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.colorRed};
+    `;
+  }}
 `;


### PR DESCRIPTION
### ✨ 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
- [x] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 기타 : 


###  작업 사항
- 디데이 삭제 기능을 구현했습니다.
- DdayItem 컴포넌트를 생성하고 기존 DdayList에 있던 코드들을 DdayItem으로 옮겼습니다.
- 디데이 등록화면에서 취소(x버튼)을 눌러도 새로고침 되는 이슈가 있어 form에 onSubmit을 걸어주어 새로고침 이슈를 해결했습니다.
- 오늘보다 이전의 날짜로 설정하는 경우 +로 보이도록 하여 목표를 세운 날짜 뿐 아니라 기념일도 챙길 수 있도록 구현했습니다. (ex. 운동시작한지 D+120, 내 생일까지 D-17 등...)  


### 📸 스크린샷

![투두삭제](https://github.com/Jeongeum/MyTodoSite/assets/77143425/1073713e-9a07-4d93-8667-2cb27647382c)


### ✅ Issue Number
close : #20
